### PR TITLE
Update readme to fix change order of port mapping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,19 +116,20 @@ documentation](http://dokku.viewdocs.io/dokku/advanced-usage/proxy-management/#p
 Because we want Sentry to be available on the default port `80` (or `443` for
 SSL), we need to fiddle around with the proxy settings.
 
-First remove the proxy mapping added by Dokku.
+First add the proxy mapping that sentry uses.
+
+```
+dokku proxy:ports-add sentry http:80:9000
+```
+
+Then, remove the proxy mapping added by Dokku.
 
 ```
 dokku proxy:ports-remove sentry http:80:5000
 ```
 
-If `dokku proxy:report sentry` shows that `DOKKU_PROXY_PORT_MAP` is not empty,
-remove all remaining port mappings. Next add the correct port mapping for this
-project.
-
-```
-dokku proxy:ports-add sentry http:80:9000
-```
+If `dokku proxy:report sentry` shows more than one port mapping, 
+remove all port mappings except the added above.
 
 ## Push Sentry to Dokku
 


### PR DESCRIPTION
Removing the only port mapping didn't work for me, i could only remove the default port mapping after i had added another. That's why i think this should be in the documentation, as with this order the install will always work.